### PR TITLE
Update volume visibility logic

### DIFF
--- a/src/WNPCallbacks.ts
+++ b/src/WNPCallbacks.ts
@@ -45,7 +45,11 @@ export function updateIcons(wnp: WNPRedux, mainLabel: vscode.StatusBarItem, volu
     mainLabel.show();
 
     volumeLabel.text = replaceMacros(wnp, volumeText);
-    volumeLabel.show();
+    if (configuration.get('WebNowPlaying.showVolume')) {
+        volumeLabel.show();
+    } else {
+        volumeLabel.hide();
+    }
 }
 
 function parseLrc(content: string) {


### PR DESCRIPTION
## Summary
- handle `WebNowPlaying.showVolume` when updating icons

## Testing
- `npm test` *(fails: Failed to parse response from https://update.code.visualstudio.com/api/releases/stable as JSON)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3bc5b2c8323a7f8692f17dd8061